### PR TITLE
fix: avoid null pointer exception

### DIFF
--- a/src/XliffParser/XliffParserV1.php
+++ b/src/XliffParser/XliffParserV1.php
@@ -269,11 +269,11 @@ class XliffParserV1 extends AbstractXliffParser
         $at = [];
         $at['attr'] = $this->extractTagAttributes($altTrans);
 
-        if ($altTrans->getElementsByTagName('source')) {
+        if ($altTrans->getElementsByTagName('source')->length > 0) {
             $at['source'] = $altTrans->getElementsByTagName('source')->item(0)->nodeValue;
         }
 
-        if ($altTrans->getElementsByTagName('target')) {
+        if ($altTrans->getElementsByTagName('target')->length > 0) {
             $at['target'] = $altTrans->getElementsByTagName('target')->item(0)->nodeValue;
         }
 

--- a/src/XliffParser/XliffParserV1.php
+++ b/src/XliffParser/XliffParserV1.php
@@ -273,7 +273,7 @@ class XliffParserV1 extends AbstractXliffParser
             $at['source'] = $altTrans->getElementsByTagName('source')->item(0)->nodeValue;
         }
 
-        if ($altTrans->getElementsByTagName('target')->length > 0) {
+        if ($altTrans->getElementsByTagName('target')) {
             $at['target'] = $altTrans->getElementsByTagName('target')->item(0)->nodeValue;
         }
 


### PR DESCRIPTION
When source or target child elements not exists the $altTrans->getElementsByTagName('source')->item(0) results null and its not possible to get the property nodeValue of null.

Example alt-trans block with unexisting source:
```
<alt-trans origin="machine-trans">
     <target/>
</alt-trans>
<alt-trans origin="memsource-tm">
     <target/>
</alt-trans>
```