### PR TITLE
Correct handling of xliff tags inside <data-original>

### DIFF
--- a/src/Constants/Placeholder.php
+++ b/src/Constants/Placeholder.php
@@ -12,4 +12,6 @@ class Placeholder
     const WHITE_SPACE_PLACEHOLDER = '###___WHITE_SPACE_PLACEHOLDER___###';
     const NEW_LINE_PLACEHOLDER = '###___NEW_LINE_PLACEHOLDER___###';
     const TAB_PLACEHOLDER = '###___TAB_PLACEHOLDER___###';
+    const LT_PLACEHOLDER = '###___LT_PLACEHOLDER___###';
+    const GT_PLACEHOLDER = '###___GT_PLACEHOLDER___###';
 }

--- a/src/Constants/XliffTags.php
+++ b/src/Constants/XliffTags.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Matecat\XliffParser\Constants;
+
+class XliffTags
+{
+    /**
+     * List of allowed Xliff tags
+     */
+    public static $tags = [ 'g', 'x', 'bx', 'ex', 'bpt', 'ept', 'ph', 'pc', 'ec', 'sc', 'it', 'mrk' ];
+}

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -2,6 +2,7 @@
 
 namespace Matecat\XliffParser\Utils;
 
+use Matecat\XliffParser\Constants\XliffTags;
 use Matecat\XliffParser\Exception\NotValidJSONException;
 
 class Strings
@@ -113,17 +114,16 @@ class Strings
      * <g id="1">Hello</g>, 4 > 3 &gt; -> <g id="1">Hello</g>, 4 &gt; 3 &gt; 2
      *
      * @param string $content
-     * @param bool $escapeStrings
+     * @param bool   $escapeStrings
      *
      * @return mixed|string
      */
-    public static function fixNonWellFormedXml($content, $escapeStrings = true)
+    public static function fixNonWellFormedXml( $content, $escapeStrings = true)
     {
         if (self::$find_xliff_tags_reg === null) {
-            // List of the tags that we don't want to escape
-            $xliff_tags = [ 'g', 'x', 'bx', 'ex', 'bpt', 'ept', 'ph', 'pc', 'ec', 'sc', 'it', 'mrk' ];
             // Convert the list of tags in a regexp list, for example "g|x|bx|ex"
-            $xliff_tags_reg_list = implode('|', $xliff_tags);
+            $xliffTags = XliffTags::$tags;
+            $xliff_tags_reg_list = implode('|', $xliffTags);
             // Regexp to find all the XLIFF tags:
             //   </?               -> matches the tag start, for both opening and
             //                        closure tags (see the optional slash)

--- a/src/XliffParser/XliffParserV2.php
+++ b/src/XliffParser/XliffParserV2.php
@@ -294,13 +294,25 @@ class XliffParserV2 extends AbstractXliffParser
                         $dataValue = str_replace(Placeholder::TAB_PLACEHOLDER, '\t', $dataValue);
 
                         if ('' !== $dataValue) {
+
+                            $jsonOrRawContentArray = $this->JSONOrRawContentArray($dataValue, false);
+
+                            // restore xliff tags
+                            if (isset($jsonOrRawContentArray['json'])){
+                                $jsonOrRawContentArray['json'] = str_replace([Placeholder::LT_PLACEHOLDER, Placeholder::GT_PLACEHOLDER], ['&lt;','&gt;'], $jsonOrRawContentArray['json']);
+                            }
+
+                            if (isset($jsonOrRawContentArray['raw-content'])){
+                                $jsonOrRawContentArray['raw-content'] = str_replace([Placeholder::LT_PLACEHOLDER, Placeholder::GT_PLACEHOLDER], ['&lt;','&gt;'], $jsonOrRawContentArray['raw-content']);
+                            }
+
                             $originalData[] = array_merge(
-                                    $this->JSONOrRawContentArray($dataValue, false),
-                                    [
-                                            'attr' => [
-                                                    'id' => $dataId
-                                            ]
+                                $jsonOrRawContentArray,
+                                [
+                                    'attr' => [
+                                        'id' => $dataId
                                     ]
+                                ]
                             );
                         }
                     }

--- a/tests/XliffParserV2Test.php
+++ b/tests/XliffParserV2Test.php
@@ -9,9 +9,22 @@ class XliffParserV2Test extends BaseTest
     /**
      * @test
      */
+    public function can_parse_xliff_v2_with_encoded_g_tags_in_originalData()
+    {
+        $parsed = (new XliffParser())->xliffToArray($this->getTestFile('xliff_20_with_g_tags_in_dataref.xlf'));
+        $units  = $parsed[ 'files' ][ 1 ][ 'trans-units' ];
+
+        $originalData = $units[1]['original-data'][0];
+
+        $this->assertEquals($originalData['raw-content'], '&lt;g id="0PEY7rmSqeVk51Xn" ctype="x-html-strong" /&gt;');
+        $this->assertEquals($originalData['attr']['id'], 'd1');
+    }
+
+    /**
+     * @test
+     */
     public function can_parse_xliff_v2_with_new_line_values_in_originalData()
     {
-        // <pc> tags do not be escaped here
         $parsed = (new XliffParser())->xliffToArray($this->getTestFile('blank-dataRef.xliff'));
         $units  = $parsed[ 'files' ][ 1 ][ 'trans-units' ];
 
@@ -248,7 +261,6 @@ class XliffParserV2Test extends BaseTest
         $this->assertEquals($units[4]['source']['raw-content'][0], '
                     <sc dataRef="d1" id="1" subType="xlf:b" type="fmt"/>Elysian Collection<ph dataRef="d3" id="2" subType="xlf:lb" type="fmt"/><ec dataRef="d2" startRef="1" subType="xlf:b" type="fmt"/>Bahnhofstrasse 15, Postfach 341, Zermatt CH- 3920, Switzerland<ph dataRef="d3" id="3" subType="xlf:lb" type="fmt"/>Tel: +44 203 468 2235  Email: <pc dataRefEnd="d5" dataRefStart="d4" id="4" type="link">info@elysiancollection.com</pc><sc dataRef="d1" id="5" subType="xlf:b" type="fmt"/><ph dataRef="d3" id="6" subType="xlf:lb" type="fmt"/><ec dataRef="d2" startRef="5" subType="xlf:b" type="fmt"/>');
     }
-
 
     /**
      * @test

--- a/tests/files/xliff_20_with_g_tags_in_dataref.xlf
+++ b/tests/files/xliff_20_with_g_tags_in_dataref.xlf
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US" trgLang="it-IT" xmlns:its="http://www.w3.org/2005/11/its" xmlns:itsxlf="http://www.w3.org/ns/its-xliff/" its:version="2.0">
+ <file id="f1" original="/home/afalappa/Documenti/filters-sample-docs/markdown/prova.md">
+  <unit id="tu1">
+   <originalData>
+    <data id="d1">&lt;g id="0PEY7rmSqeVk51Xn" ctype="x-html-strong" /&gt;</data>
+   </originalData>
+   <segment>
+    <source xml:space="preserve">Testo libero contenente <pc id="1" canCopy="no" canDelete="no" dataRefEnd="d1" dataRefStart="d1">un tag g</pc>.</source>
+   </segment>
+  </unit>
+  <unit id="tu2">
+   <originalData>
+    <data id="d1">&lt;a href="#"&gt;</data>
+    <data id="d2">&lt;/a&gt;</data>
+   </originalData>
+   <segment>
+    <source xml:space="preserve">Testo libero contenente <pc id="1" canCopy="no" canDelete="no" dataRefEnd="d1" dataRefStart="d2">link</pc>.</source>
+   </segment>
+  </unit>
+ </file>
+</xliff>
+


### PR DESCRIPTION
- escaped xliff tags inside <data-original> are now preserved as they were

```php
// allowed xliff tags list
[ 'g', 'x', 'bx', 'ex', 'bpt', 'ept', 'ph', 'pc', 'ec', 'sc', 'it', 'mrk' ]
```