### PR TITLE
XliffReplacer fix (segment_id too long)

### DIFF
--- a/src/XliffReplacer/SdlXliffSAXTranslationReplacer.php
+++ b/src/XliffReplacer/SdlXliffSAXTranslationReplacer.php
@@ -17,8 +17,9 @@ class SdlXliffSAXTranslationReplacer extends XliffSAXTranslationReplacer
         if ($this->tuTagName === $name) {
             $this->inTU = true;
 
-            //get id
-            $this->currentTransUnitId = $attr[ 'id' ];
+            // get id
+            // trim to first 100 characters because this is the limit on Matecat's DB
+            $this->currentTransUnitId = substr($attr[ 'id' ], 0, 100);
 
             // current 'translate' attribute of the current trans-unit
             $this->currentTransUnitTranslate = isset($attr[ 'translate' ]) ? $attr[ 'translate' ] : 'yes';

--- a/src/XliffReplacer/XliffSAXTranslationReplacer.php
+++ b/src/XliffReplacer/XliffSAXTranslationReplacer.php
@@ -104,7 +104,8 @@ class XliffSAXTranslationReplacer extends AbstractXliffReplacer
             $this->inTU = true;
 
             // get id
-            $this->currentTransUnitId = $attr[ 'id' ];
+            // trim to first 100 characters because this is the limit on Matecat's DB
+            $this->currentTransUnitId = substr($attr[ 'id' ], 0, 100);
 
             // current 'translate' attribute of the current trans-unit
             $this->currentTransUnitTranslate = isset($attr[ 'translate' ]) ? $attr[ 'translate' ] : 'yes';

--- a/tests/XliffReplacerTest.php
+++ b/tests/XliffReplacerTest.php
@@ -11,6 +11,69 @@ class XliffReplacerTest extends BaseTest
     /**
      * @test
      */
+    public function can_replace_a_xliff_12_with_very_long_segment_id()
+    {
+        $data = $this->getData([
+            [
+                'sid' => 314,
+                'segment' => 'Address Tracker Widget',
+                'internal_id' => 'CFBundleDisplayName',
+                'mrk_id' => '',
+                'prev_tags' => '',
+                'succ_tags' => '',
+                'mrk_prev_tags' => '',
+                'mrk_succ_tags' => '',
+                'translation' => 'Bla bla bla',
+                'status' => TranslationStatus::STATUS_TRANSLATED,
+                'eq_word_count' => 1,
+                'raw_word_count' => 1,
+            ],
+            [
+                'sid' => 315,
+                'segment' => 'Address Tracker WidgetExtension',
+                'internal_id' => 'CFBundleName',
+                'mrk_id' => '',
+                'prev_tags' => '',
+                'succ_tags' => '',
+                'mrk_prev_tags' => '',
+                'mrk_succ_tags' => '',
+                'translation' => 'Bla bla bla bla bla',
+                'status' => TranslationStatus::STATUS_TRANSLATED,
+                'eq_word_count' => 1,
+                'raw_word_count' => 1,
+            ],
+            [
+                'sid' => 316,
+                'segment' => 'Periodic notification trigger will be set to minimum one hour intervals. Please note that there is no guarantee it will trigger as it is decided by the system and influenced by multiple power management factors. You can add up to 5 accounts.',
+                'internal_id' => 'Periodic notification trigger will be set to minimum one hour intervals. Please note that there is n',
+                'mrk_id' => '',
+                'prev_tags' => '',
+                'succ_tags' => '',
+                'mrk_prev_tags' => '',
+                'mrk_succ_tags' => '',
+                'translation' => 'Bla bla bla bla bla bla bla',
+                'status' => TranslationStatus::STATUS_TRANSLATED,
+                'eq_word_count' => 1,
+                'raw_word_count' => 1,
+            ],
+        ]);
+
+        $inputFile = __DIR__.'/../tests/files/long-segment-id.xliff';
+        $outputFile = __DIR__.'/../tests/files/output/long-segment-id.xliff';
+
+        $xliffParser = new XliffParser();
+        $xliffParser->replaceTranslation($inputFile, $data['data'], $data['transUnits'], 'it-IT', $outputFile);
+        $output = $xliffParser->xliffToArray(file_get_contents($outputFile));
+
+        $this->assertEquals($output['files'][1]['trans-units'][1]['target']['raw-content'], 'Bla bla bla');
+        $this->assertEquals($output['files'][1]['trans-units'][2]['target']['raw-content'], 'Bla bla bla bla bla');
+        $this->assertEquals($output['files'][2]['trans-units'][1]['target']['raw-content'], 'Bla bla bla bla bla bla bla');
+    }
+
+
+    /**
+     * @test
+     */
     public function can_replace_a_xliff_12_without_target()
     {
         $data = $this->getData([
@@ -28,62 +91,62 @@ class XliffReplacerTest extends BaseTest
                 'eq_word_count' => 1,
                 'raw_word_count' => 1,
             ],
-                [
-                        'sid' => 2,
-                        'segment' => 'Bla Bla',
-                        'internal_id' => 'NFDBB2FA9-tu52',
-                        'mrk_id' => '',
-                        'prev_tags' => '',
-                        'succ_tags' => '',
-                        'mrk_prev_tags' => '',
-                        'mrk_succ_tags' => '',
-                        'translation' => 'Bla bla bla',
-                        'status' => TranslationStatus::STATUS_TRANSLATED,
-                        'eq_word_count' => 1,
-                        'raw_word_count' => 1,
-                ],
-                [
-                        'sid' => 3,
-                        'segment' => 'Bla Bla',
-                        'internal_id' => 'NFDBB2FA9-tu523',
-                        'mrk_id' => '',
-                        'prev_tags' => '',
-                        'succ_tags' => '',
-                        'mrk_prev_tags' => '',
-                        'mrk_succ_tags' => '',
-                        'translation' => 'Bla bla bla',
-                        'status' => TranslationStatus::STATUS_TRANSLATED,
-                        'eq_word_count' => 1,
-                        'raw_word_count' => 1,
-                ],
-                [
-                        'sid' => 4,
-                        'segment' => 'Bla Bla',
-                        'internal_id' => 'NFDBB2FA9-tu523',
-                        'mrk_id' => '',
-                        'prev_tags' => '',
-                        'succ_tags' => '',
-                        'mrk_prev_tags' => '',
-                        'mrk_succ_tags' => '',
-                        'translation' => 'Bla bla bla',
-                        'status' => TranslationStatus::STATUS_TRANSLATED,
-                        'eq_word_count' => 1,
-                        'raw_word_count' => 1,
-                ],
-                [
-                        'sid' => 5,
-                        'segment' => 'Bla Bla',
-                        'internal_id' => 'NFDBB2FA9-tu522',
-                        'mrk_id' => '',
-                        'prev_tags' => '',
-                        'succ_tags' => '',
-                        'mrk_prev_tags' => '',
-                        'mrk_succ_tags' => '',
-                        'translation' => 'Bla bla bla',
-                        'status' => TranslationStatus::STATUS_TRANSLATED,
-                        'eq_word_count' => 1,
-                        'raw_word_count' => 1,
-                ],
+            [
+                'sid' => 2,
+                'segment' => 'Bla Bla',
+                'internal_id' => 'NFDBB2FA9-tu52',
+                'mrk_id' => '',
+                'prev_tags' => '',
+                'succ_tags' => '',
+                'mrk_prev_tags' => '',
+                'mrk_succ_tags' => '',
+                'translation' => 'Bla bla bla',
+                'status' => TranslationStatus::STATUS_TRANSLATED,
+                'eq_word_count' => 1,
+                'raw_word_count' => 1,
+            ],
+            [
+                'sid' => 3,
+                'segment' => 'Bla Bla',
+                'internal_id' => 'NFDBB2FA9-tu523',
+                'mrk_id' => '',
+                'prev_tags' => '',
+                'succ_tags' => '',
+                'mrk_prev_tags' => '',
+                'mrk_succ_tags' => '',
+                'translation' => 'Bla bla bla',
+                'status' => TranslationStatus::STATUS_TRANSLATED,
+                'eq_word_count' => 1,
+                'raw_word_count' => 1,
+            ],
+            [
+                'sid' => 4,
+                'segment' => 'Bla Bla',
+                'internal_id' => 'NFDBB2FA9-tu523',
+                'mrk_id' => '',
+                'prev_tags' => '',
+                'succ_tags' => '',
+                'mrk_prev_tags' => '',
+                'mrk_succ_tags' => '',
+                'translation' => 'Bla bla bla',
+                'status' => TranslationStatus::STATUS_TRANSLATED,
+                'eq_word_count' => 1,
+                'raw_word_count' => 1,
+            ],
+            [
+                'sid' => 5,
+                'segment' => 'Bla Bla',
+                'internal_id' => 'NFDBB2FA9-tu522',
+                'mrk_id' => '',
+                'prev_tags' => '',
+                'succ_tags' => '',
+                'mrk_prev_tags' => '',
+                'mrk_succ_tags' => '',
+                'translation' => 'Bla bla bla',
+                'status' => TranslationStatus::STATUS_TRANSLATED,
+                'eq_word_count' => 1,
+                'raw_word_count' => 1,
+            ],
         ]);
 
         $inputFile = __DIR__.'/../tests/files/file-with-nested-group-and-missing-target.xliff';

--- a/tests/files/long-segment-id.xliff
+++ b/tests/files/long-segment-id.xliff
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+    <file original="Address Tracker Widget/en.lproj/InfoPlist.strings" datatype="plaintext" source-language="en" target-language="it-IT">
+        <header>
+            <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5"></tool></header>
+        <body>
+            <trans-unit id="CFBundleDisplayName" xml:space="preserve">
+        <source>Address Tracker Widget</source>
+                <target xml:lang="it-IT">Widget Tracker indirizzi</target>
+                <note>Bundle display name</note>
+      </trans-unit>
+            <trans-unit id="CFBundleName" xml:space="preserve">
+        <source>Address Tracker WidgetExtension</source>
+                <target xml:lang="it-IT">Estensione Widget Tracker indirizzo</target>
+                <note>Bundle name</note>
+      </trans-unit>
+        </body>
+    </file>
+    <file original="Address Tracker Widget/en.lproj/Localizable.strings" source-language="en" target-language="it-IT" datatype="plaintext">
+        <header>
+            <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5"></tool></header>
+        <body>
+            <trans-unit id="Periodic notification trigger will be set to minimum one hour intervals. Please note that there is no guarantee it will trigger as it is decided by the system and influenced by multiple power management factors. You can add up to 5 accounts." xml:space="preserve">
+        <source>Periodic notification trigger will be set to minimum one hour intervals. Please note that there is no guarantee it will trigger as it is decided by the system and influenced by multiple power management factors. You can add up to 5 accounts.</source>
+                <target xml:lang="it-IT">Periodic notification trigger will be set to minimum one hour intervals. Please note that there is no guarantee it will trigger as it is decided by the system and influenced by multiple power management factors. You can add up to 5 accounts.</target>
+                <note>No comment provided by engineer.</note>
+      </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/tests/files/output/long-segment-id.xliff
+++ b/tests/files/output/long-segment-id.xliff
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd" xmlns:mtc="https://www.matecat.com">
+    <file original="Address Tracker Widget/en.lproj/InfoPlist.strings" datatype="plaintext" source-language="en" target-language="it-IT">
+        <header>
+            <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5"></tool></header>
+        <body>
+            <trans-unit help-id="314" id="CFBundleDisplayName" xml:space="preserve">
+        <source>Address Tracker Widget</source>
+                <target  xml:lang="it-IT" state="translated">Bla bla bla</target>
+<count-group name="CFBundleDisplayName"><count count-type="x-matecat-raw">1</count><count count-type="x-matecat-weighted">1</count></count-group>
+                <note>Bundle display name</note>
+      </trans-unit>
+            <trans-unit help-id="315" id="CFBundleName" xml:space="preserve">
+        <source>Address Tracker WidgetExtension</source>
+                <target  xml:lang="it-IT" state="translated">Bla bla bla bla bla</target>
+<count-group name="CFBundleName"><count count-type="x-matecat-raw">2</count><count count-type="x-matecat-weighted">2</count></count-group>
+                <note>Bundle name</note>
+      </trans-unit>
+        </body>
+    </file>
+    <file original="Address Tracker Widget/en.lproj/Localizable.strings" source-language="en" target-language="it-IT" datatype="plaintext">
+        <header>
+            <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.5"></tool></header>
+        <body>
+            <trans-unit help-id="316" id="Periodic notification trigger will be set to minimum one hour intervals. Please note that there is no guarantee it will trigger as it is decided by the system and influenced by multiple power management factors. You can add up to 5 accounts." xml:space="preserve">
+        <source>Periodic notification trigger will be set to minimum one hour intervals. Please note that there is no guarantee it will trigger as it is decided by the system and influenced by multiple power management factors. You can add up to 5 accounts.</source>
+                <target  xml:lang="it-IT" state="translated">Bla bla bla bla bla bla bla</target>
+<count-group name="Periodic notification trigger will be set to minimum one hour intervals. Please note that there is n"><count count-type="x-matecat-raw">3</count><count count-type="x-matecat-weighted">3</count></count-group>
+                <note>No comment provided by engineer.</note>
+      </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
Now `currentTransUnitId` variable is trimmed to the first 100 characters in order to fit with Matecat's limit.