### PR TITLE
Improving HTMLParser

### DIFF
--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -341,16 +341,21 @@ class Strings
     }
 
     /**
+     * @TODO We need to improve this
      * @param string $string
      *
      * @return bool
      */
-    public static function isHtmlString( $string )
+    public static function isHtmlString($string)
     {
+        $string = stripslashes($string);
+
         if($string === '<>'){
             return false;
         }
 
-        return strip_tags($string) !== $string;
+        preg_match("/<\/?[a-zA-Z1-6-]+((\s+\w+(\s*=\s*(?:\".*?\"|'.*?'|[^'\">\s]+))?)+\s*|\s*)\/?>/",$string, $matches);
+
+        return count($matches) !== 0;
     }
 }

--- a/src/XliffUtils/DataRefReplacer.php
+++ b/src/XliffUtils/DataRefReplacer.php
@@ -184,7 +184,7 @@ class DataRefReplacer
      */
     private function stringContainsPcTags($string, $toBeEscaped)
     {
-        $regex = ($toBeEscaped) ? '/&lt;pc(.*?)&gt;/iu' : '/<pc(.*?)>/iu';
+        $regex = ($toBeEscaped) ? '/&lt;pc (.*?)&gt;/iu' : '/<pc (.*?)>/iu';
         preg_match_all($regex, $string, $openingPcMatches);
 
         return (isset($openingPcMatches[0]) and count($openingPcMatches[0])>0);
@@ -273,7 +273,7 @@ class DataRefReplacer
      */
     private function replaceOpeningPcTags($string, $toBeEscaped)
     {
-        $regex = ($toBeEscaped) ? '/&lt;pc(.*?)&gt;/iu' : '/<pc(.*?)>/iu';
+        $regex = ($toBeEscaped) ? '/&lt;pc (.*?)&gt;/iu' : '/<pc (.*?)>/iu';
         preg_match_all($regex, $string, $openingPcMatches);
 
         foreach ($openingPcMatches[0] as $index => $match){

--- a/tests/DataReplacerTest.php
+++ b/tests/DataReplacerTest.php
@@ -10,6 +10,26 @@ class DataReplacerTest extends BaseTest
     /**
      * @test
      */
+    public function can_replace_pc_with_adjacent_angle_brackets()
+    {
+        $map = [
+            'source1' => 'a',
+            'source2' => 'b',
+            'source3' => 'c',
+        ];
+
+        $dataReplacer = new DataRefReplacer($map);
+
+        $string = '&lt;pc id="source1" dataRefStart="source1"&gt;Age (if exact date is not available&lt;/pc&gt;&lt;pc id="source2" dataRefStart="source2"&gt; &lt;day,month,year&gt;&nbsp; &lt;/pc&gt;&lt;pc id="source3" dataRefStart="source3"&gt;or we have work/education history to prove the age difference)&lt;/pc&gt;';
+        $expected = '&lt;ph id="source1_1" dataType="pcStart" originalData="Jmx0O3BjIGlkPSJzb3VyY2UxIiBkYXRhUmVmU3RhcnQ9InNvdXJjZTEiJmd0Ow==" dataRef="source1" equiv-text="base64:YQ=="/&gt;Age (if exact date is not available&lt;ph id="source1_2" dataType="pcEnd" originalData="Jmx0Oy9wYyZndDs=" dataRef="source1" equiv-text="base64:YQ=="/&gt;&lt;ph id="source2_1" dataType="pcStart" originalData="Jmx0O3BjIGlkPSJzb3VyY2UyIiBkYXRhUmVmU3RhcnQ9InNvdXJjZTIiJmd0Ow==" dataRef="source2" equiv-text="base64:Yg=="/&gt; &lt;day,month,year&gt;&nbsp; &lt;ph id="source2_2" dataType="pcEnd" originalData="Jmx0Oy9wYyZndDs=" dataRef="source2" equiv-text="base64:Yg=="/&gt;&lt;ph id="source3_1" dataType="pcStart" originalData="Jmx0O3BjIGlkPSJzb3VyY2UzIiBkYXRhUmVmU3RhcnQ9InNvdXJjZTMiJmd0Ow==" dataRef="source3" equiv-text="base64:Yw=="/&gt;or we have work/education history to prove the age difference)&lt;ph id="source3_2" dataType="pcEnd" originalData="Jmx0Oy9wYyZndDs=" dataRef="source3" equiv-text="base64:Yw=="/&gt;';
+
+        $this->assertEquals($expected, $dataReplacer->replace($string));
+        $this->assertEquals($string, $dataReplacer->restore($expected));
+    }
+
+    /**
+     * @test
+     */
     public function can_replace_ph_with_null_values_in_original_map()
     {
         $map = [

--- a/tests/StringsTest.php
+++ b/tests/StringsTest.php
@@ -12,12 +12,22 @@ class StringsTest extends BaseTest
     public function can_check_html_tag()
     {
         $a = "<div>ciao</div>";
+        $b = "< >";
+        $c = "<day,month,year>";
+        $d = "<a href='#'>";
+        $e = "<h1>";
+        $f = "<a href='#@,'>";
+        $g = '<ph id=\"source1\" dataRef=\"source1\"/>';
+        $h = '<trans-unit id="pendo-image-e3aaf7b7|alt">';
 
         $this->assertTrue(Strings::isHtmlString($a));
-
-        $a = "< >";
-
-        $this->assertFalse(Strings::isHtmlString($a));
+        $this->assertFalse(Strings::isHtmlString($b));
+        $this->assertFalse(Strings::isHtmlString($c));
+        $this->assertTrue(Strings::isHtmlString($d));
+        $this->assertTrue(Strings::isHtmlString($e));
+        $this->assertTrue(Strings::isHtmlString($f));
+        $this->assertTrue(Strings::isHtmlString($g));
+        $this->assertTrue(Strings::isHtmlString($h));
     }
 
     /**


### PR DESCRIPTION
`Strings::isHtmlString` method used by `HTMLParser` was improved (regex added).

Now is capable to understand that:

`<year,month, save>`

is not a valid HTML string.
