### PR TITLE
Update xliffToArray.md

### DIFF
--- a/docs/xliffToArray.md
+++ b/docs/xliffToArray.md
@@ -8,8 +8,10 @@ To convert a xliff file into an array:
 // ...
 use Matecat\XliffParser\XliffParser;
 
+$xmlContent = file_get_contents('path/to/your/file.xliff');
 $parser = new XliffParser();
-$parsed = $parser->xliffToArray('path/to/your/file.xliff');
+$parsed = $parser->xliffToArray($xmlContent);
+
 ```
 
 In case of invalid or not supported xliff file an Exception is thrown.


### PR DESCRIPTION
Passing the file path as a parameter will result in the information that the XLIFF could not be parsed.
This occurs because the function expects the XML document and not the PATH to the XML document.
If file_get_contents is used to read the XML and the result is passed to the xliffToArray() function, it works as intended