### PR TITLE
Removed deprecation for PHP7.4

### DIFF
--- a/src/Utils/Emoji.php
+++ b/src/Utils/Emoji.php
@@ -7417,7 +7417,7 @@ class Emoji
      */
     public static function toEntity($str)
     {
-        $letters = preg_split( '//u', $str, null, PREG_SPLIT_NO_EMPTY );
+        $letters = preg_split( '//u', $str, -1, PREG_SPLIT_NO_EMPTY );
         foreach( $letters as $letter ){
             if(@self::$chmap[ $letter ]){
                 $str = str_replace( $letter, self::$chmap[ $letter ], $str );


### PR DESCRIPTION
Removed deprecation (PHP7.4):

```PHP Deprecated:  preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated

Linea 7420:
$letters = preg_split( '//u', $str, null, PREG_SPLIT_NO_EMPTY );
```