### PR TITLE
Fix for V1 Parser (Duplicated ids)

### DIFF
--- a/src/XliffParser/XliffParserV1.php
+++ b/src/XliffParser/XliffParserV1.php
@@ -195,7 +195,7 @@ class XliffParserV1 extends AbstractXliffParser
      * @return array
      * @throws \Exception
      */
-    private function extractTransUnitMetadata(\DOMElement $transUnit, array $transUnitIdArrayForUniquenessCheck)
+    private function extractTransUnitMetadata(\DOMElement $transUnit, array &$transUnitIdArrayForUniquenessCheck)
     {
         $metadata = [];
 

--- a/tests/XliffParserV1Test.php
+++ b/tests/XliffParserV1Test.php
@@ -573,4 +573,16 @@ class XliffParserV1Test extends BaseTest
         $this->assertEquals('Ciao. ', $transUnit['seg-source'][2]['raw-content']);
         $this->assertEquals('Ciao.', $transUnit['seg-source'][3]['raw-content']);
     }
+
+    /**
+     * @test
+     */
+    public function raise_exception_on_duplicate_ids()
+    {
+        try {
+            (new XliffParser())->xliffToArray($this->getTestFile('v1-duplicate-ids.xliff'));
+        } catch (\Exception $exception){
+            $this->assertEquals('Invalid trans-unit id, duplicate found.', $exception->getMessage());
+        }
+    }
 }

--- a/tests/XliffParserV2Test.php
+++ b/tests/XliffParserV2Test.php
@@ -439,4 +439,16 @@ class XliffParserV2Test extends BaseTest
 
         $this->assertArraySimilar($parsed[ 'files' ][ 1 ], $exp);
     }
+
+    /**
+     * @test
+     */
+    public function raise_exception_on_duplicate_ids()
+    {
+        try {
+            (new XliffParser())->xliffToArray($this->getTestFile('v2-duplicate-ids.xliff'));
+        } catch (\Exception $exception){
+            $this->assertEquals('Invalid trans-unit id, duplicate found.', $exception->getMessage());
+        }
+    }
 }

--- a/tests/files/v1-duplicate-ids.xliff
+++ b/tests/files/v1-duplicate-ids.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:tos="GMAPS: https://www.matecat.com/translated-os" encoding="UTF-8" version="1.2">
+    <tool tool-id="TranslationOS" tos:allow-segmentation="yes"/>
+    <file datatype="html" original="052c458d-faaa-437f-b9d2-96af06b706c5" source-language="en-US" target-language="ko-KO" tos:description="Airbnb city portal is an external portal for governments that will serve as a medium for jurisdictions to better understand–and regulate–home sharing within their communities.">
+        <body>
+            <trans-unit id="01234" translate="no">
+    		    <source xml:lang="en-US">DON'T TRANSLATE</source><target>DON'T TRANSLATE</target>
+    		</trans-unit>
+    		<trans-unit id="606beaf1-a66d-4464-9bdf-cedd857b79a7">
+		        <source xml:lang="en-US">Daegu</source>
+		        <note>City: Daegu</note><note>State: Daegu</note>
+		        <note>Country code: KR</note>
+		        <note>Type: geo</note>
+		        <note>Wikidata : https://www.wikidata.org/wiki/Q20927</note>
+		        <note>Wikipedia : https://en.wikipedia.org/wiki/Daegu</note>
+		        <note>Geo: 35.8714354,128.601445</note>
+		        <note>Gmaps: https://www.google.com/maps/place/Daegu%2CDaegu%2CDaegu%2CKR%2C/@35.8714354,128.601445,12z</note>
+            </trans-unit>
+            <trans-unit id="606beaf1-a66d-4464-9bdf-cedd857b79a7">
+		        <source xml:lang="en-US">Daegu</source>
+		        <note>City: Daegu</note><note>State: Daegu</note>
+		        <note>Country code: KR</note>
+		        <note>Type: geo names</note>
+		        <note>Wikidata : https://www.wikidata.org/wiki/Q20927</note>
+		        <note>Wikipedia : https://en.wikipedia.org/wiki/Daegu</note>
+		        <note>Geo: 35.8714354,128.601445</note>
+		        <note>Gmaps: https://www.google.com/maps/place/Daegu%2CDaegu%2CDaegu%2CKR%2C/@35.8714354,128.601445,12z</note>
+            </trans-unit>
+		</body>
+    </file>
+</xliff>

--- a/tests/files/v2-duplicate-ids.xliff
+++ b/tests/files/v2-duplicate-ids.xliff
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US" trgLang="it-IT" xmlns:its="http://www.w3.org/2005/11/its" its:version="2.0">
+	<file id="f1" original="/home/afalappa/Documenti/filters-sample-docs/markdown/prova.md">
+		<unit id="tu1">
+			<segment>
+				<source xml:space="preserve">First unit</source>
+			</segment>
+		</unit>
+		<unit id="tu1">
+			<segment>
+				<source xml:space="preserve">First unit</source>
+			</segment>
+		</unit>
+	</file>
+</xliff>


### PR DESCRIPTION
Fix on `XliffParserV1`: raise exception on duplicated ids