### PR TITLE
Guard array element access with `isset()` instead of `@` in Emoji.php

### DIFF
--- a/src/Utils/Emoji.php
+++ b/src/Utils/Emoji.php
@@ -7458,7 +7458,7 @@ class Emoji {
     public static function toEntity( $str ) {
         $letters = preg_split( '//u', $str, null, PREG_SPLIT_NO_EMPTY );
         foreach ( $letters as $letter ) {
-            if ( @self::$chmap[ $letter ] ) {
+            if ( self::$chmap[ $letter ] ?? false ) {
                 $str = str_replace( $letter, self::$chmap[ $letter ], $str );
             }
         }

--- a/src/Utils/Emoji.php
+++ b/src/Utils/Emoji.php
@@ -7458,7 +7458,7 @@ class Emoji {
     public static function toEntity( $str ) {
         $letters = preg_split( '//u', $str, null, PREG_SPLIT_NO_EMPTY );
         foreach ( $letters as $letter ) {
-            if ( self::$chmap[ $letter ] ?? false ) {
+            if ( isset ( self::$chmap[ $letter ] ) ) {
                 $str = str_replace( $letter, self::$chmap[ $letter ], $str );
             }
         }


### PR DESCRIPTION
`@` prevents warnings from being printed, but it does not prevent them from being reported to debugger by Xdebug. Since most characters tend not to be emoji, the flood of notices sent to the debugger slows parsing to a crawl. Null-coalesce the element access to false instead.

(To think I almost discarded a perfectly good XLIFF library because I thought it was too :snail: :wink:)