### PR TITLE
Add support for name parsing in metadata for v2

### DIFF
--- a/src/XliffParser/XliffParserV2.php
+++ b/src/XliffParser/XliffParserV2.php
@@ -248,6 +248,11 @@ class XliffParserV2 extends AbstractXliffParser {
         $transUnitIdArrayForUniquenessCheck[] = $id;
         $metadata[ 'id' ]                     = $id;
 
+        // name
+        if ( null !== $transUnit->attributes->getNamedItem( 'name' ) ) {
+            $metadata[ 'name' ] = $transUnit->attributes->getNamedItem( 'name' )->nodeValue;
+        }
+        
         // translate
         if ( null !== $transUnit->attributes->getNamedItem( 'translate' ) ) {
             $metadata[ 'translate' ] = $transUnit->attributes->getNamedItem( 'translate' )->nodeValue;


### PR DESCRIPTION
Hi,

When I work with XLIFF files, it might be necessary to get the name of the translation I am working with. Currently, the name is not included in the metadata of the individual translations. The proposed change introduces parsing of the name into the metadata. I hope this can be of use to others as well!